### PR TITLE
Make graph building deterministic

### DIFF
--- a/src/fast_graph_builder.rs
+++ b/src/fast_graph_builder.rs
@@ -18,7 +18,7 @@
  */
 
 use std::cmp::max;
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 use priority_queue::PriorityQueue;
 
@@ -91,7 +91,7 @@ impl FastGraphBuilder {
         let mut rank = 0;
         while !queue.is_empty() {
             let node = queue.pop().unwrap().0;
-            let mut neighbors = HashSet::new();
+            let mut neighbors = BTreeSet::new();
             for out_edge in &preparation_graph.out_edges[node] {
                 neighbors.insert(out_edge.adj_node);
                 self.fast_graph.edges_fwd.push(FastGraphEdge::new(

--- a/src/preparation_graph.rs
+++ b/src/preparation_graph.rs
@@ -146,7 +146,7 @@ impl PreparationGraph {
 
     fn assert_valid_node_id(&self, node: NodeId) {
         assert!(
-            node >= 0 && node < self.num_nodes,
+            node < self.num_nodes,
             format!(
                 "invalid node id {}, must be in [0, {}[",
                 node, self.num_nodes


### PR DESCRIPTION
The map building pipeline in A/B Street needs to be deterministic (given the same OSM input, of course). I discovered the node ordering and some edge weights weren't, and it's an easy fix.