### PR TITLE
Mark a dependency as test-only, so this crate compiles to wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,7 @@ bincode = "1.1.2"
 serde = { version = "1.0", features =["derive"] }
 log = "0.4"
 rand = "0.6"
-stopwatch = "0.0.7"
 priority-queue = "0.6.0"
+
+[dev-dependencies]
+stopwatch = "0.0.7"


### PR DESCRIPTION
Tested by compiling one of my crates that depends on fast_paths using wasm-pack