### PR TITLE
Allow storing the graph for 32bit systems on a 64bit system.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ fast_paths::save_to_disk(&fast_graph, "fast_graph.fp");
 let fast_graph = fast_paths::load_from_disk("fast_graph.fp");
 ```
 
+To be able to use the graph in a 32bit WebAssembly environment the graph needs to be transformed to a 32bit representation when using a 64bit system. This can be achieved
+with these two methods:
+```rust
+fast_paths::save_to_disk32(&fast_graph, "fast_graph32.fp");
+let fast_graph = fast_paths::load_from_disk32("fast_graph32.fp");
+```
+
 ### Preparing the graph after changes
 
 The graph preparation can be done much faster using a fixed node ordering, which is just a permutation of node ids. This can be done like this:

--- a/README.md
+++ b/README.md
@@ -69,11 +69,12 @@ fast_paths::save_to_disk(&fast_graph, "fast_graph.fp");
 let fast_graph = fast_paths::load_from_disk("fast_graph.fp");
 ```
 
-To be able to use the graph in a 32bit WebAssembly environment it needs to be transformed to a 32bit representation when using a 64bit system. This can be achieved with these two methods. Using these methods will only work for graphs that do not exceed the 32bit limit. The resulting size on disk will be 50% less than when using `save_to_disk`, but 50% more RAM will be needed during the process of saving the graph to disk.
+To be able to use the graph in a 32bit WebAssembly environment it needs to be transformed to a 32bit representation when preparing it on a 64bit system. This can be achieved with the following two methods, but it will only work for graphs that do not exceed the 32bit limit.
 ```rust
 fast_paths::save_to_disk32(&fast_graph, "fast_graph32.fp");
 let fast_graph = fast_paths::load_from_disk32("fast_graph32.fp");
 ```
+Note that the resulting size on disk will be 50% less than when using `save_to_disk`, but 50% more RAM will be needed during the process of saving the graph to disk.
 
 ### Preparing the graph after changes
 

--- a/README.md
+++ b/README.md
@@ -69,8 +69,7 @@ fast_paths::save_to_disk(&fast_graph, "fast_graph.fp");
 let fast_graph = fast_paths::load_from_disk("fast_graph.fp");
 ```
 
-To be able to use the graph in a 32bit WebAssembly environment the graph needs to be transformed to a 32bit representation when using a 64bit system. This can be achieved
-with these two methods:
+To be able to use the graph in a 32bit WebAssembly environment it needs to be transformed to a 32bit representation when using a 64bit system. This can be achieved with these two methods. Using these methods will only work for graphs that do not exceed the 32bit limit. The resulting size on disk will be 50% less than when using `save_to_disk`, but 50% more RAM will be needed during the process of saving the graph to disk.
 ```rust
 fast_paths::save_to_disk32(&fast_graph, "fast_graph32.fp");
 let fast_graph = fast_paths::load_from_disk32("fast_graph32.fp");

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ fast_paths::save_to_disk(&fast_graph, "fast_graph.fp");
 let fast_graph = fast_paths::load_from_disk("fast_graph.fp");
 ```
 
-To be able to use the graph in a 32bit WebAssembly environment it needs to be transformed to a 32bit representation when preparing it on a 64bit system. This can be achieved with the following two methods, but it will only work for graphs that do not exceed the 32bit limit.
+To be able to use the graph in a 32bit WebAssembly environment it needs to be transformed to a 32bit representation when preparing it on a 64bit system. This can be achieved with the following two methods, but it will only work for graphs that do not exceed the 32bit limit, i.e. the number of nodes and edges and all weights must be below 2^32.
 ```rust
 fast_paths::save_to_disk32(&fast_graph, "fast_graph32.fp");
 let fast_graph = fast_paths::load_from_disk32("fast_graph32.fp");

--- a/src/fast_graph32.rs
+++ b/src/fast_graph32.rs
@@ -67,7 +67,6 @@ impl FastGraph32 {
     }
 }
 
-
 /// 32bit equivalent to `FastGraphEdge`, see `FastGraph32` docs.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct FastGraphEdge32 {
@@ -82,7 +81,8 @@ fn usize_to_u32(int: usize) -> u32 {
     if int.eq(&std::usize::MAX) {
         return usize_to_u32(std::u32::MAX as usize);
     }
-    return u32::try_from(int).expect(format!("Could not convert {} to a 32bit integer", int).as_str());
+    return u32::try_from(int)
+        .expect(format!("Could not convert {} to a 32bit integer", int).as_str());
 }
 
 fn usize_to_u32_vec(vec: &Vec<usize>) -> Vec<u32> {
@@ -141,11 +141,15 @@ mod tests {
         let ranks = vec![286, 45, 480_001, std::usize::MAX, 4468];
         let edges_fwd = vec![
             FastGraphEdge::new(std::usize::MAX, 598, 48, std::usize::MAX, std::usize::MAX),
-            FastGraphEdge::new(std::usize::MAX, std::usize::MAX, std::usize::MAX, 4, std::usize::MAX),
+            FastGraphEdge::new(
+                std::usize::MAX,
+                std::usize::MAX,
+                std::usize::MAX,
+                4,
+                std::usize::MAX,
+            ),
         ];
-        let edges_bwd = vec![
-            FastGraphEdge::new(0, 1, 3, 4, std::usize::MAX),
-        ];
+        let edges_bwd = vec![FastGraphEdge::new(0, 1, 3, 4, std::usize::MAX)];
         let first_edge_ids_fwd = vec![1, std::usize::MAX, std::usize::MAX];
         let first_edge_ids_bwd = vec![1, std::usize::MAX, 5, std::usize::MAX, 9, 10];
 
@@ -190,7 +194,10 @@ mod tests {
         // briefly check back-conversion
         let g_from32 = g32.convert_to_usize();
         assert_eq!(g_from32.get_num_nodes(), 5);
-        assert_eq!(g_from32.ranks, vec![286, 45, 480_001, std::usize::MAX, 4468]);
+        assert_eq!(
+            g_from32.ranks,
+            vec![286, 45, 480_001, std::usize::MAX, 4468]
+        );
         assert_eq!(g_from32.first_edge_ids_fwd[2], std::usize::MAX);
         assert_eq!(g_from32.first_edge_ids_bwd[0], 1);
         assert_eq!(g_from32.first_edge_ids_bwd[1], std::usize::MAX);

--- a/src/fast_graph32.rs
+++ b/src/fast_graph32.rs
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use std::convert::TryFrom;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::fast_graph::FastGraphEdge;
+use crate::FastGraph;
+
+/// Special graph data-structure that is identical to `FastGraph` except that it uses u32 integers
+/// instead of usize integers. This is used to store a `FastGraph` in a 32bit representation on disk
+/// when using a 64bit system.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct FastGraph32 {
+    num_nodes: u32,
+    pub ranks: Vec<u32>,
+    pub edges_fwd: Vec<FastGraphEdge32>,
+    pub first_edge_ids_fwd: Vec<u32>,
+
+    pub edges_bwd: Vec<FastGraphEdge32>,
+    pub first_edge_ids_bwd: Vec<u32>,
+}
+
+impl FastGraph32 {
+    /// Creates a 32bit Graph from a given `FastGraph`. All (potentially 64bit) `usize` integers are
+    /// simply converted to u32 and if a value exceeds the 32bit limit an error is thrown. The only
+    /// exception is `std::u32::MAX`, which is converted to `std::usize::MAX`.
+    pub fn new(fast_graph: &FastGraph) -> Self {
+        FastGraph32 {
+            num_nodes: usize_to_u32(fast_graph.get_num_nodes()),
+            ranks: usize_to_u32_vec(&fast_graph.ranks),
+            edges_fwd: usize_to_u32_edges(&fast_graph.edges_fwd),
+            first_edge_ids_fwd: usize_to_u32_vec(&fast_graph.first_edge_ids_fwd),
+            edges_bwd: usize_to_u32_edges(&fast_graph.edges_bwd),
+            first_edge_ids_bwd: usize_to_u32_vec(&fast_graph.first_edge_ids_bwd),
+        }
+    }
+
+    /// Converts a 32bit Graph to an actual `FastGraph` using `usize` such that it can be used with
+    /// FastPaths crate. Any integers that equal `std::u32::MAX` are mapped to `std::usize::MAX`.
+    pub fn convert_to_usize(self) -> FastGraph {
+        let mut g = FastGraph::new(self.num_nodes as usize);
+        g.ranks = u32_to_usize_vec(&self.ranks);
+        g.edges_fwd = u32_to_usize_edges(&self.edges_fwd);
+        g.first_edge_ids_fwd = u32_to_usize_vec(&self.first_edge_ids_fwd);
+        g.edges_bwd = u32_to_usize_edges(&self.edges_bwd);
+        g.first_edge_ids_bwd = u32_to_usize_vec(&self.first_edge_ids_bwd);
+        return g;
+    }
+}
+
+
+/// 32bit equivalent to `FastGraphEdge`, see `FastGraph32` docs.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct FastGraphEdge32 {
+    pub base_node: u32,
+    pub adj_node: u32,
+    pub weight: u32,
+    pub replaced_in_edge: u32,
+    pub replaced_out_edge: u32,
+}
+
+fn usize_to_u32(int: usize) -> u32 {
+    if int.eq(&std::usize::MAX) {
+        return usize_to_u32(std::u32::MAX as usize);
+    }
+    return u32::try_from(int).expect(format!("Could not convert {} to a 32bit integer", int).as_str());
+}
+
+fn usize_to_u32_vec(vec: &Vec<usize>) -> Vec<u32> {
+    return vec.iter().map(|i| usize_to_u32(*i)).collect();
+}
+
+fn usize_to_u32_edges(vec: &Vec<FastGraphEdge>) -> Vec<FastGraphEdge32> {
+    return vec.iter().map(|e| usize_to_u32_edge(e)).collect();
+}
+
+fn usize_to_u32_edge(edge: &FastGraphEdge) -> FastGraphEdge32 {
+    return FastGraphEdge32 {
+        base_node: usize_to_u32(edge.base_node),
+        adj_node: usize_to_u32(edge.adj_node),
+        weight: usize_to_u32(edge.weight),
+        replaced_in_edge: usize_to_u32(edge.replaced_in_edge),
+        replaced_out_edge: usize_to_u32(edge.replaced_out_edge),
+    };
+}
+
+fn u32_to_usize(int: u32) -> usize {
+    if int.eq(&std::u32::MAX) {
+        return std::usize::MAX;
+    }
+    return int as usize;
+}
+
+fn u32_to_usize_vec(vec: &Vec<u32>) -> Vec<usize> {
+    return vec.iter().map(|i| u32_to_usize(*i)).collect();
+}
+
+fn u32_to_usize_edges(vec: &Vec<FastGraphEdge32>) -> Vec<FastGraphEdge> {
+    return vec.iter().map(|e| u32_to_usize_edge(e)).collect();
+}
+
+fn u32_to_usize_edge(edge: &FastGraphEdge32) -> FastGraphEdge {
+    return FastGraphEdge {
+        base_node: u32_to_usize(edge.base_node),
+        adj_node: u32_to_usize(edge.adj_node),
+        weight: u32_to_usize(edge.weight),
+        replaced_in_edge: u32_to_usize(edge.replaced_in_edge),
+        replaced_out_edge: u32_to_usize(edge.replaced_out_edge),
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::fast_graph::FastGraph;
+    use crate::fast_graph::FastGraphEdge;
+
+    use super::*;
+
+    #[test]
+    fn create() {
+        let num_nodes = 5;
+        let ranks = vec![286, 45, 480_001, std::usize::MAX, 4468];
+        let edges_fwd = vec![
+            FastGraphEdge::new(std::usize::MAX, 598, 48, std::usize::MAX, std::usize::MAX),
+            FastGraphEdge::new(std::usize::MAX, std::usize::MAX, std::usize::MAX, 4, std::usize::MAX),
+        ];
+        let edges_bwd = vec![
+            FastGraphEdge::new(0, 1, 3, 4, std::usize::MAX),
+        ];
+        let first_edge_ids_fwd = vec![1, std::usize::MAX, std::usize::MAX];
+        let first_edge_ids_bwd = vec![1, std::usize::MAX, 5, std::usize::MAX, 9, 10];
+
+        let mut g = FastGraph::new(num_nodes);
+        g.ranks = ranks;
+        g.edges_fwd = edges_fwd;
+        g.first_edge_ids_fwd = first_edge_ids_fwd;
+        g.edges_bwd = edges_bwd;
+        g.first_edge_ids_bwd = first_edge_ids_bwd;
+
+        let g32 = FastGraph32::new(&g);
+        assert_eq!(g32.num_nodes, 5);
+
+        assert_eq!(g32.ranks.len(), 5);
+        assert_eq!(g32.ranks[0], 286);
+        assert_eq!(g32.ranks[2], 480_001);
+        assert_eq!(g32.ranks[3], std::u32::MAX);
+
+        assert_eq!(g32.edges_fwd.len(), 2);
+        assert_eq!(g32.edges_fwd[0].base_node, std::u32::MAX);
+        assert_eq!(g32.edges_fwd[0].adj_node, 598);
+        assert_eq!(g32.edges_fwd[0].weight, 48);
+        assert_eq!(g32.edges_fwd[0].replaced_in_edge, std::u32::MAX);
+        assert_eq!(g32.edges_fwd[0].replaced_out_edge, std::u32::MAX);
+
+        assert_eq!(g32.edges_fwd[1].base_node, std::u32::MAX);
+        assert_eq!(g32.edges_fwd[1].adj_node, std::u32::MAX);
+        assert_eq!(g32.edges_fwd[1].weight, std::u32::MAX);
+        assert_eq!(g32.edges_fwd[1].replaced_in_edge, 4);
+        assert_eq!(g32.edges_fwd[1].replaced_out_edge, std::u32::MAX);
+
+        assert_eq!(g32.edges_bwd.len(), 1);
+        assert_eq!(g32.edges_bwd[0].weight, 3);
+        assert_eq!(g32.edges_bwd[0].replaced_out_edge, std::u32::MAX);
+
+        assert_eq!(g32.first_edge_ids_fwd.len(), 3);
+        assert_eq!(g32.first_edge_ids_fwd[1], std::u32::MAX);
+        assert_eq!(g32.first_edge_ids_bwd.len(), 6);
+        assert_eq!(g32.first_edge_ids_bwd[3], std::u32::MAX);
+        assert_eq!(g32.first_edge_ids_bwd[4], 9);
+
+        // briefly check back-conversion
+        let g_from32 = g32.convert_to_usize();
+        assert_eq!(g_from32.get_num_nodes(), 5);
+        assert_eq!(g_from32.ranks, vec![286, 45, 480_001, std::usize::MAX, 4468]);
+        assert_eq!(g_from32.first_edge_ids_fwd[2], std::usize::MAX);
+        assert_eq!(g_from32.first_edge_ids_bwd[0], 1);
+        assert_eq!(g_from32.first_edge_ids_bwd[1], std::usize::MAX);
+        assert_eq!(g_from32.edges_fwd[0].base_node, std::usize::MAX);
+        assert_eq!(g_from32.edges_fwd[0].adj_node, 598);
+        assert_eq!(g_from32.edges_fwd[0].weight, 48);
+        assert_eq!(g_from32.edges_bwd[0].replaced_in_edge, 4);
+    }
+
+    #[test]
+    #[should_panic]
+    fn create_fails_with_too_large_numbers() {
+        let num_nodes = 5;
+        let mut g = FastGraph::new(num_nodes);
+        g.ranks = vec![5_000_000_000];
+        let g32 = FastGraph32::new(&g);
+    }
+}

--- a/src/fast_graph32.rs
+++ b/src/fast_graph32.rs
@@ -213,6 +213,6 @@ mod tests {
         let num_nodes = 5;
         let mut g = FastGraph::new(num_nodes);
         g.ranks = vec![5_000_000_000];
-        let g32 = FastGraph32::new(&g);
+        FastGraph32::new(&g);
     }
 }

--- a/src/fast_graph32.rs
+++ b/src/fast_graph32.rs
@@ -63,7 +63,7 @@ impl FastGraph32 {
         g.first_edge_ids_fwd = u32_to_usize_vec(&self.first_edge_ids_fwd);
         g.edges_bwd = u32_to_usize_edges(&self.edges_bwd);
         g.first_edge_ids_bwd = u32_to_usize_vec(&self.first_edge_ids_bwd);
-        return g;
+        g
     }
 }
 
@@ -78,54 +78,59 @@ pub struct FastGraphEdge32 {
 }
 
 fn usize_to_u32(int: usize) -> u32 {
-    if int.eq(&std::usize::MAX) {
-        return usize_to_u32(std::u32::MAX as usize);
+    if int == std::usize::MAX {
+        usize_to_u32(std::u32::MAX as usize)
+    } else {
+        if let Ok(x) = u32::try_from(int) {
+            x
+        } else {
+            panic!("Could not convert {} to a 32-bit integer", int);
+        }
     }
-    return u32::try_from(int)
-        .expect(format!("Could not convert {} to a 32bit integer", int).as_str());
 }
 
 fn usize_to_u32_vec(vec: &Vec<usize>) -> Vec<u32> {
-    return vec.iter().map(|i| usize_to_u32(*i)).collect();
+    vec.iter().map(|i| usize_to_u32(*i)).collect()
 }
 
 fn usize_to_u32_edges(vec: &Vec<FastGraphEdge>) -> Vec<FastGraphEdge32> {
-    return vec.iter().map(|e| usize_to_u32_edge(e)).collect();
+    vec.iter().map(|e| usize_to_u32_edge(e)).collect()
 }
 
 fn usize_to_u32_edge(edge: &FastGraphEdge) -> FastGraphEdge32 {
-    return FastGraphEdge32 {
+    FastGraphEdge32 {
         base_node: usize_to_u32(edge.base_node),
         adj_node: usize_to_u32(edge.adj_node),
         weight: usize_to_u32(edge.weight),
         replaced_in_edge: usize_to_u32(edge.replaced_in_edge),
         replaced_out_edge: usize_to_u32(edge.replaced_out_edge),
-    };
+    }
 }
 
 fn u32_to_usize(int: u32) -> usize {
-    if int.eq(&std::u32::MAX) {
-        return std::usize::MAX;
+    if int == std::u32::MAX {
+        std::usize::MAX
+    } else {
+        int as usize
     }
-    return int as usize;
 }
 
 fn u32_to_usize_vec(vec: &Vec<u32>) -> Vec<usize> {
-    return vec.iter().map(|i| u32_to_usize(*i)).collect();
+    vec.iter().map(|i| u32_to_usize(*i)).collect()
 }
 
 fn u32_to_usize_edges(vec: &Vec<FastGraphEdge32>) -> Vec<FastGraphEdge> {
-    return vec.iter().map(|e| u32_to_usize_edge(e)).collect();
+    vec.iter().map(|e| u32_to_usize_edge(e)).collect()
 }
 
 fn u32_to_usize_edge(edge: &FastGraphEdge32) -> FastGraphEdge {
-    return FastGraphEdge {
+    FastGraphEdge {
         base_node: u32_to_usize(edge.base_node),
         adj_node: u32_to_usize(edge.adj_node),
         weight: u32_to_usize(edge.weight),
         replaced_in_edge: u32_to_usize(edge.replaced_in_edge),
         replaced_out_edge: u32_to_usize(edge.replaced_out_edge),
-    };
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,8 @@ use std::error::Error;
 use std::fs::File;
 
 pub use crate::constants::*;
-pub use crate::fast_graph32::FastGraph32;
 pub use crate::fast_graph::FastGraph;
+pub use crate::fast_graph32::FastGraph32;
 pub use crate::fast_graph_builder::FastGraphBuilder;
 pub use crate::fast_graph_builder::Params;
 pub use crate::input_graph::Edge;
@@ -126,8 +126,8 @@ mod tests {
     use std::fs::remove_file;
     use std::time::SystemTime;
 
-    use rand::Rng;
     use rand::rngs::StdRng;
+    use rand::Rng;
     use stopwatch::Stopwatch;
 
     use crate::constants::NodeId;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,9 +94,17 @@ pub fn save_to_disk(fast_graph: &FastGraph, file_name: &str) -> Result<(), Box<d
     Ok(bincode::serialize_into(file, fast_graph)?)
 }
 
+/// Restores a prepared graph from disk
+pub fn load_from_disk(file_name: &str) -> Result<FastGraph, Box<dyn Error>> {
+    let file = File::open(file_name)?;
+    Ok(bincode::deserialize_from(file)?)
+}
+
 /// Saves the given prepared graph to disk thereby enforcing a 32bit representation no matter whether
 /// the system in use uses 32 or 64bit. This is useful when creating the graph on a 64bit system and
 /// afterwards loading it on a 32bit system.
+/// Note: Using this method requires an extra +50% of RAM while storing the graph (even though
+/// the graph will use 50% *less* disk space when it has been saved.
 pub fn save_to_disk32(fast_graph: &FastGraph, file_name: &str) -> Result<(), Box<dyn Error>> {
     let fast_graph32 = &FastGraph32::new(fast_graph);
     let file = File::create(file_name)?;
@@ -106,16 +114,11 @@ pub fn save_to_disk32(fast_graph: &FastGraph, file_name: &str) -> Result<(), Box
 /// Loads a graph from disk that was saved in 32bit representation, i.e. using save_to_disk32. The
 /// graph will use usize to store integers, so most commonly either 32 or 64bits per integer
 /// depending on the system in use.
+/// Note: Using this method requires an extra +50% RAM while loading the graph.
 pub fn load_from_disk32(file_name: &str) -> Result<FastGraph, Box<dyn Error>> {
     let file = File::open(file_name)?;
     let r: Result<FastGraph32, Box<dyn Error>> = Ok(bincode::deserialize_from(file)?);
     return r.map(|g| g.convert_to_usize());
-}
-
-/// Restores a prepared graph from disk
-pub fn load_from_disk(file_name: &str) -> Result<FastGraph, Box<dyn Error>> {
-    let file = File::open(file_name)?;
-    Ok(bincode::deserialize_from(file)?)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,12 +50,12 @@ mod valid_flags;
 
 /// Prepares the given `InputGraph` for fast shortest path calculations.
 pub fn prepare(input_graph: &InputGraph) -> FastGraph {
-    return FastGraphBuilder::build(input_graph);
+    FastGraphBuilder::build(input_graph)
 }
 
 /// Like `prepare()`, but allows specifying some parameters used for the graph preparation.
 pub fn prepare_with_params(input_graph: &InputGraph, params: &Params) -> FastGraph {
-    return FastGraphBuilder::build_with_params(input_graph, params);
+    FastGraphBuilder::build_with_params(input_graph, params)
 }
 
 /// Prepares the given input graph using a fixed node ordering, which can be any permutation
@@ -66,13 +66,13 @@ pub fn prepare_with_order(
     input_graph: &InputGraph,
     order: &Vec<NodeId>,
 ) -> Result<FastGraph, String> {
-    return FastGraphBuilder::build_with_order(input_graph, order);
+    FastGraphBuilder::build_with_order(input_graph, order)
 }
 
 /// Calculates the shortest path from `source` to `target`.
 pub fn calc_path(fast_graph: &FastGraph, source: NodeId, target: NodeId) -> Option<ShortestPath> {
     let mut calc = PathCalculator::new(fast_graph.get_num_nodes());
-    return calc.calc_path(fast_graph, source, target);
+    calc.calc_path(fast_graph, source, target)
 }
 
 /// Creates a `PathCalculator` that can be used to run many shortest path calculations in a row.
@@ -118,7 +118,7 @@ pub fn save_to_disk32(fast_graph: &FastGraph, file_name: &str) -> Result<(), Box
 pub fn load_from_disk32(file_name: &str) -> Result<FastGraph, Box<dyn Error>> {
     let file = File::open(file_name)?;
     let r: Result<FastGraph32, Box<dyn Error>> = Ok(bincode::deserialize_from(file)?);
-    return r.map(|g| g.convert_to_usize());
+    r.map(|g| g.convert_to_usize())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR adds two helper methods to save/load a graph (which uses usize integers) in a 32bit representation. This allows writing a 32bit graph also on a 64bit system. A 32bit graph might be needed when using FastPaths with WebAssembly.

Fixes #12. 