### PR TITLE
Adding derives for Clone and Copy where it makes sense

### DIFF
--- a/src/fast_graph.rs
+++ b/src/fast_graph.rs
@@ -23,7 +23,7 @@ use serde::Serialize;
 use crate::constants::Weight;
 use crate::constants::{EdgeId, NodeId, INVALID_EDGE};
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct FastGraph {
     num_nodes: usize,
     pub(crate) ranks: Vec<usize>,
@@ -83,7 +83,7 @@ impl FastGraph {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub struct FastGraphEdge {
     // todo: the base_node is 'redundant' for the routing query so to say, but makes the implementation easier for now
     // and can still be removed at a later time, we definitely need this information on original

--- a/src/fast_graph32.rs
+++ b/src/fast_graph32.rs
@@ -28,7 +28,7 @@ use crate::FastGraph;
 /// Special graph data-structure that is identical to `FastGraph` except that it uses u32 integers
 /// instead of usize integers. This is used to store a `FastGraph` in a 32bit representation on disk
 /// when using a 64bit system.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct FastGraph32 {
     num_nodes: u32,
     pub ranks: Vec<u32>,
@@ -68,7 +68,7 @@ impl FastGraph32 {
 }
 
 /// 32bit equivalent to `FastGraphEdge`, see `FastGraph32` docs.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub struct FastGraphEdge32 {
     pub base_node: u32,
     pub adj_node: u32,

--- a/src/input_graph.rs
+++ b/src/input_graph.rs
@@ -32,7 +32,7 @@ use serde::{Deserialize, Serialize};
 use crate::constants::NodeId;
 use crate::constants::Weight;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct InputGraph {
     edges: Vec<Edge>,
     num_nodes: usize,
@@ -210,7 +210,7 @@ impl fmt::Debug for InputGraph {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 pub struct Edge {
     pub from: NodeId,
     pub to: NodeId,

--- a/src/node_contractor.rs
+++ b/src/node_contractor.rs
@@ -80,7 +80,7 @@ fn add_shortcut(graph: &mut PreparationGraph, shortcut: Shortcut) {
     );
 }
 
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug, Copy, Clone)]
 pub struct Shortcut {
     from: NodeId,
     to: NodeId,

--- a/src/shortest_path.rs
+++ b/src/shortest_path.rs
@@ -22,7 +22,7 @@ use crate::constants::Weight;
 use crate::constants::WEIGHT_MAX;
 use crate::constants::WEIGHT_ZERO;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ShortestPath {
     source: NodeId,
     target: NodeId,


### PR DESCRIPTION
Adds `Clone` Derives on custom structs, and a few `Copy`, to allow users of the lib to clone `InputGraph` and `FastGraph`.

Haven't added a unit-test as it compiles and is a derivation so it seems pointless, did a quick sanity check though and the cloning works