### PR TITLE
Allow pathfinding between multiple weighted sources and targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ let mut path_calculator = fast_paths::create_calculator(&fast_graph);
 let shortest_path = path_calculator.calc_path(&fast_graph, 8, 6);
 ```
 
+### Calculating paths between multiple sources and targets
+
+We can also efficiently calculate the shortest path when we want to consider multiple sources or targets:
+
+```rust
+// ... see above
+// we want to either start at node 2 or 3 both of which carry a different initial weight
+let sources = vec![(3, 5), (2, 7)];
+// ... and go to either node 6 or 8 which also both carry a cost upon arrival
+let targets = vec![(6, 2), (8, 10)];
+// calculate the path with minimum cost that connects any of the sources with any of the targets while taking into 
+// account the initial weights of each source and node
+let shortest_path = path_calculator.calc_path_multiple_sources_and_targets(&fast_graph, sources, targets);
+```
+
 ### Serializing the prepared graph
 
 `FastGraph` implements standard [Serde](https://serde.rs/) serialization.

--- a/changelog
+++ b/changelog
@@ -1,3 +1,5 @@
+0.3.0 (not yet released)
+      add calc_path_multiple_sources_and_targets, #30
 0.2.0 add clone and copy derives, #26
       faster fast_graph building
       faster queries (stall on demand optimization), #18

--- a/src/fast_graph_builder.rs
+++ b/src/fast_graph_builder.rs
@@ -350,13 +350,14 @@ mod tests {
 
     #[test]
     fn multiple_sources() {
-        // 0 -> 1 -> 2
+        // 0 -> 1 -> 2 <- 5
         // 3 -> 4 ->/
         let mut input_graph = InputGraph::new();
         input_graph.add_edge(0, 1, 3);
         input_graph.add_edge(1, 2, 4);
         input_graph.add_edge(3, 4, 2);
         input_graph.add_edge(4, 2, 3);
+        input_graph.add_edge(5, 2, 2);
         input_graph.freeze();
         let fast_graph = prepare(&input_graph);
         let mut path_calculator = create_calculator(&fast_graph);
@@ -387,6 +388,15 @@ mod tests {
             2,
             vec![0, 1, 2],
             10,
+        );
+        // ... now put the smaller weight first
+        assert_path_multiple_sources_and_targets(
+            &mut path_calculator,
+            &fast_graph,
+            vec![(5, 10), (5, 20)],
+            2,
+            vec![5, 2],
+            12,
         );
         // start options equal the target
         assert_path_multiple_sources_and_targets(
@@ -440,7 +450,7 @@ mod tests {
         expected_nodes: Vec<NodeId>,
         expected_weight: Weight,
     ) {
-        let fast_path = path_calculator.calc_path_multiple_endpoints(&fast_graph, sources, target);
+        let fast_path = path_calculator.calc_path_multiple_endpoints(fast_graph, sources, target);
         assert!(fast_path.is_some());
         let p = fast_path.unwrap();
         assert_eq!(expected_nodes, p.get_nodes().clone(), "unexpected nodes");

--- a/src/fast_graph_builder.rs
+++ b/src/fast_graph_builder.rs
@@ -442,6 +442,29 @@ mod tests {
         );
     }
 
+    #[test]
+    fn multiple_targets() {
+        // 0 <- 1 <- 2
+        // 3 <- 4 <-/
+        let mut input_graph = InputGraph::new();
+        input_graph.add_edge(1, 0, 3);
+        input_graph.add_edge(2, 1, 4);
+        input_graph.add_edge(4, 3, 2);
+        input_graph.add_edge(2, 4, 3);
+        input_graph.freeze();
+        let fast_graph = prepare(&input_graph);
+        let mut path_calculator = create_calculator(&fast_graph);
+        // two different options for target, without initial weight
+        assert_path_multiple_sources_and_targets(
+            &mut path_calculator,
+            &fast_graph,
+            vec![(2, 0)],
+            vec![(0, 0), (3, 0)],
+            vec![2, 4, 3],
+            5,
+        );
+    }
+
     fn assert_path_multiple_sources_and_targets(
         path_calculator: &mut PathCalculator,
         fast_graph: &FastGraph,

--- a/src/fast_graph_builder.rs
+++ b/src/fast_graph_builder.rs
@@ -366,7 +366,7 @@ mod tests {
             &mut path_calculator,
             &fast_graph,
             vec![(0, 0), (3, 0)],
-            2,
+            vec![(2, 0)],
             vec![3, 4, 2],
             5,
         );
@@ -376,7 +376,7 @@ mod tests {
             &mut path_calculator,
             &fast_graph,
             vec![(0, 1), (3, 4)],
-            2,
+            vec![(2, 0)],
             vec![0, 1, 2],
             8,
         );
@@ -385,7 +385,7 @@ mod tests {
             &mut path_calculator,
             &fast_graph,
             vec![(0, 5), (0, 3)],
-            2,
+            vec![(2, 0)],
             vec![0, 1, 2],
             10,
         );
@@ -394,7 +394,7 @@ mod tests {
             &mut path_calculator,
             &fast_graph,
             vec![(5, 10), (5, 20)],
-            2,
+            vec![(2, 0)],
             vec![5, 2],
             12,
         );
@@ -403,7 +403,7 @@ mod tests {
             &mut path_calculator,
             &fast_graph,
             vec![(1, 10), (1, 1)],
-            1,
+            vec![(1, 0)],
             vec![1],
             1,
         );
@@ -412,7 +412,7 @@ mod tests {
             &mut path_calculator,
             &fast_graph,
             vec![(2, 10), (0, 0)],
-            2,
+            vec![(2, 0)],
             vec![0, 1, 2],
             7,
         );
@@ -421,14 +421,14 @@ mod tests {
             &mut path_calculator,
             &fast_graph,
             vec![(1, WEIGHT_MAX)],
-            1,
+            vec![(1, 0)],
         );
         // .. or at least they are ignored in case there are other ones
         assert_path_multiple_sources_and_targets(
             &mut path_calculator,
             &fast_graph,
             vec![(1, WEIGHT_MAX), (0, 3)],
-            1,
+            vec![(1, 0)],
             vec![0, 1],
             6,
         );
@@ -436,7 +436,7 @@ mod tests {
             &mut path_calculator,
             &fast_graph,
             vec![(1, WEIGHT_MAX), (3, 3)],
-            2,
+            vec![(2, 0)],
             vec![3, 4, 2],
             8,
         );
@@ -446,11 +446,11 @@ mod tests {
         path_calculator: &mut PathCalculator,
         fast_graph: &FastGraph,
         sources: Vec<(NodeId, Weight)>,
-        target: usize,
+        targets: Vec<(NodeId, Weight)>,
         expected_nodes: Vec<NodeId>,
         expected_weight: Weight,
     ) {
-        let fast_path = path_calculator.calc_path_multiple_endpoints(fast_graph, sources, target);
+        let fast_path = path_calculator.calc_path_multiple_endpoints(fast_graph, sources, targets);
         assert!(fast_path.is_some());
         let p = fast_path.unwrap();
         assert_eq!(expected_nodes, p.get_nodes().clone(), "unexpected nodes");
@@ -461,9 +461,9 @@ mod tests {
         path_calculator: &mut PathCalculator,
         fast_graph: &FastGraph,
         sources: Vec<(NodeId, Weight)>,
-        target: usize,
+        targets: Vec<(NodeId, Weight)>,
     ) {
-        let fast_path = path_calculator.calc_path_multiple_endpoints(&fast_graph, sources, target);
+        let fast_path = path_calculator.calc_path_multiple_endpoints(&fast_graph, sources, targets);
         assert!(fast_path.is_none(), "there should be no path");
     }
 }

--- a/src/fast_graph_builder.rs
+++ b/src/fast_graph_builder.rs
@@ -487,7 +487,7 @@ mod tests {
             vec![(4, 0)],
             vec![(4, 3), (4, 1)],
             vec![4],
-            1
+            1,
         )
     }
 
@@ -513,7 +513,7 @@ mod tests {
             vec![(1, 7), (6, 2), (5, 6)],
             vec![(3, 1), (4, 9), (5, 7)],
             vec![6, 2, 3],
-            12
+            12,
         );
         assert_path_multiple_sources_and_targets(
             &mut path_calculator,
@@ -521,7 +521,7 @@ mod tests {
             vec![(1, 7), (6, 2)],
             vec![(1, 9), (6, 3)],
             vec![6],
-            5
+            5,
         );
     }
 

--- a/src/fast_graph_builder.rs
+++ b/src/fast_graph_builder.rs
@@ -533,7 +533,8 @@ mod tests {
         expected_nodes: Vec<NodeId>,
         expected_weight: Weight,
     ) {
-        let fast_path = path_calculator.calc_path_multiple_endpoints(fast_graph, sources, targets);
+        let fast_path =
+            path_calculator.calc_path_multiple_sources_and_targets(fast_graph, sources, targets);
         assert!(fast_path.is_some());
         let p = fast_path.unwrap();
         assert_eq!(expected_nodes, p.get_nodes().clone(), "unexpected nodes");
@@ -546,7 +547,8 @@ mod tests {
         sources: Vec<(NodeId, Weight)>,
         targets: Vec<(NodeId, Weight)>,
     ) {
-        let fast_path = path_calculator.calc_path_multiple_endpoints(&fast_graph, sources, targets);
+        let fast_path =
+            path_calculator.calc_path_multiple_sources_and_targets(&fast_graph, sources, targets);
         assert!(fast_path.is_none(), "there should be no path");
     }
 }

--- a/src/fast_graph_builder.rs
+++ b/src/fast_graph_builder.rs
@@ -463,6 +463,66 @@ mod tests {
             vec![2, 4, 3],
             5,
         );
+        // two different options for target, with initial weight
+        assert_path_multiple_sources_and_targets(
+            &mut path_calculator,
+            &fast_graph,
+            vec![(2, 0)],
+            vec![(0, 0), (3, 1)],
+            vec![2, 4, 3],
+            6,
+        );
+        assert_path_multiple_sources_and_targets(
+            &mut path_calculator,
+            &fast_graph,
+            vec![(2, 0)],
+            vec![(0, 0), (3, 3)],
+            vec![2, 1, 0],
+            7,
+        );
+        // start==end
+        assert_path_multiple_sources_and_targets(
+            &mut path_calculator,
+            &fast_graph,
+            vec![(4, 0)],
+            vec![(4, 3), (4, 1)],
+            vec![4],
+            1
+        )
+    }
+
+    #[test]
+    fn multiple_sources_and_targets() {
+        // 0 -- 1 -- 2 -- 3 -- 4
+        // 5 -- 6 --/ \-- 7 -- 8
+        let mut input_graph = InputGraph::new();
+        input_graph.add_edge_bidir(0, 1, 1);
+        input_graph.add_edge_bidir(1, 2, 2);
+        input_graph.add_edge_bidir(2, 3, 3);
+        input_graph.add_edge_bidir(3, 4, 4);
+        input_graph.add_edge_bidir(5, 6, 5);
+        input_graph.add_edge_bidir(6, 2, 6);
+        input_graph.add_edge_bidir(2, 7, 7);
+        input_graph.add_edge_bidir(7, 8, 8);
+        input_graph.freeze();
+        let fast_graph = prepare(&input_graph);
+        let mut path_calculator = create_calculator(&fast_graph);
+        assert_path_multiple_sources_and_targets(
+            &mut path_calculator,
+            &fast_graph,
+            vec![(1, 7), (6, 2), (5, 6)],
+            vec![(3, 1), (4, 9), (5, 7)],
+            vec![6, 2, 3],
+            12
+        );
+        assert_path_multiple_sources_and_targets(
+            &mut path_calculator,
+            &fast_graph,
+            vec![(1, 7), (6, 2)],
+            vec![(1, 9), (6, 3)],
+            vec![6],
+            5
+        );
     }
 
     fn assert_path_multiple_sources_and_targets(

--- a/src/fast_graph_builder.rs
+++ b/src/fast_graph_builder.rs
@@ -265,7 +265,7 @@ mod tests {
     use super::*;
     // todo: maybe move these tests and the ones in lib.rs into the 'tests' folder as integration tests
     //       see rust docs
-    use crate::{calc_path, prepare_with_order, prepare, create_calculator, PathCalculator};
+    use crate::{calc_path, prepare_with_order, prepare, create_calculator, PathCalculator, WEIGHT_MAX};
 
     #[test]
     fn calc_path_linear_bwd_only() {
@@ -404,6 +404,30 @@ mod tests {
             vec![0, 1, 2],
             7,
         );
+        // start options with max weight cannot yield a shortest path
+        assert_path_multiple_sources_and_targets_not_found(
+            &mut pc,
+            &g,
+            vec![(1, WEIGHT_MAX)],
+            1,
+        );
+        // .. or at least they are ignored in case there are other ones
+        assert_path_multiple_sources_and_targets(
+            &mut pc,
+            &g,
+            vec![(1, WEIGHT_MAX), (0, 3)],
+            1,
+            vec![0, 1],
+            6
+        );
+        assert_path_multiple_sources_and_targets(
+            &mut pc,
+            &g,
+            vec![(1, WEIGHT_MAX), (3, 3)],
+            2,
+            vec![3, 4, 2],
+            8
+        );
     }
 
     fn assert_path_multiple_sources_and_targets(
@@ -419,6 +443,16 @@ mod tests {
         let p = fast_path.unwrap();
         assert_eq!(expected_nodes, p.get_nodes().clone(), "unexpected nodes");
         assert_eq!(expected_weight, p.get_weight(), "unexpected weight");
+    }
+
+    fn assert_path_multiple_sources_and_targets_not_found(
+        path_calculator: &mut PathCalculator,
+        fast_graph: &FastGraph,
+        sources: Vec<(NodeId, Weight)>,
+        target: usize
+    ) {
+        let fast_path = path_calculator.calc_path_multiple_endpoints(&fast_graph, sources, target);
+        assert!(fast_path.is_none(), "there should be no path");
     }
 
 }

--- a/src/fast_graph_builder.rs
+++ b/src/fast_graph_builder.rs
@@ -265,7 +265,9 @@ mod tests {
     use super::*;
     // todo: maybe move these tests and the ones in lib.rs into the 'tests' folder as integration tests
     //       see rust docs
-    use crate::{calc_path, prepare_with_order, prepare, create_calculator, PathCalculator, WEIGHT_MAX};
+    use crate::{
+        calc_path, create_calculator, prepare, prepare_with_order, PathCalculator, WEIGHT_MAX,
+    };
 
     #[test]
     fn calc_path_linear_bwd_only() {
@@ -356,12 +358,12 @@ mod tests {
         input_graph.add_edge(3, 4, 2);
         input_graph.add_edge(4, 2, 3);
         input_graph.freeze();
-        let g = prepare(&input_graph);
-        let mut pc = create_calculator(&g);
+        let fast_graph = prepare(&input_graph);
+        let mut path_calculator = create_calculator(&fast_graph);
         // two different options for source, without initial weight
         assert_path_multiple_sources_and_targets(
-            &mut pc,
-            &g,
+            &mut path_calculator,
+            &fast_graph,
             vec![(0, 0), (3, 0)],
             2,
             vec![3, 4, 2],
@@ -370,8 +372,8 @@ mod tests {
         // two different options for source, with initial weights, 0->1->2's weight is higher,
         // but since the initial weight is smaller it is the shortest path
         assert_path_multiple_sources_and_targets(
-            &mut pc,
-            &g,
+            &mut path_calculator,
+            &fast_graph,
             vec![(0, 1), (3, 4)],
             2,
             vec![0, 1, 2],
@@ -379,8 +381,8 @@ mod tests {
         );
         // one option appearing twice with different initial weights, the smaller one should be taken
         assert_path_multiple_sources_and_targets(
-            &mut pc,
-            &g,
+            &mut path_calculator,
+            &fast_graph,
             vec![(0, 5), (0, 3)],
             2,
             vec![0, 1, 2],
@@ -388,8 +390,8 @@ mod tests {
         );
         // start options equal the target
         assert_path_multiple_sources_and_targets(
-            &mut pc,
-            &g,
+            &mut path_calculator,
+            &fast_graph,
             vec![(1, 10), (1, 1)],
             1,
             vec![1],
@@ -397,8 +399,8 @@ mod tests {
         );
         // one of the start options equals the target, but still the shortest path is another one
         assert_path_multiple_sources_and_targets(
-            &mut pc,
-            &g,
+            &mut path_calculator,
+            &fast_graph,
             vec![(2, 10), (0, 0)],
             2,
             vec![0, 1, 2],
@@ -406,27 +408,27 @@ mod tests {
         );
         // start options with max weight cannot yield a shortest path
         assert_path_multiple_sources_and_targets_not_found(
-            &mut pc,
-            &g,
+            &mut path_calculator,
+            &fast_graph,
             vec![(1, WEIGHT_MAX)],
             1,
         );
         // .. or at least they are ignored in case there are other ones
         assert_path_multiple_sources_and_targets(
-            &mut pc,
-            &g,
+            &mut path_calculator,
+            &fast_graph,
             vec![(1, WEIGHT_MAX), (0, 3)],
             1,
             vec![0, 1],
-            6
+            6,
         );
         assert_path_multiple_sources_and_targets(
-            &mut pc,
-            &g,
+            &mut path_calculator,
+            &fast_graph,
             vec![(1, WEIGHT_MAX), (3, 3)],
             2,
             vec![3, 4, 2],
-            8
+            8,
         );
     }
 
@@ -449,10 +451,9 @@ mod tests {
         path_calculator: &mut PathCalculator,
         fast_graph: &FastGraph,
         sources: Vec<(NodeId, Weight)>,
-        target: usize
+        target: usize,
     ) {
         let fast_path = path_calculator.calc_path_multiple_endpoints(&fast_graph, sources, target);
         assert!(fast_path.is_none(), "there should be no path");
     }
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@ mod tests {
     }
 
     #[test]
-    fn multi_source_routing_on_random_graph() {
+    fn routing_with_multiple_sources_and_targets_on_random_graph() {
         const REPEATS: usize = 20;
         for _ in 0..REPEATS {
             const NUM_NODES: usize = 50;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,19 +74,19 @@ pub fn calc_path(fast_graph: &FastGraph, source: NodeId, target: NodeId) -> Opti
     calc.calc_path(fast_graph, source, target)
 }
 
-/// Calculates the shortest path from any of the `sources` to a single `target`.
+/// Calculates the shortest path from any of the `sources` to any of the `targets`.
 ///
-/// The path returned will start at the source node that's closest to `target`. An additional
-/// weight for each source can be specified.
-///
-/// TODO: Support multiple targets.
-pub fn calc_path_multiple_endpoints(
+/// The path returned will be the one with minimum weight among all possible paths between the sources
+/// and targets. The sources and targets can also be assigned an initial weight. In this case the
+/// path returned will be the one that minimizes start_weight + path-weight + target_weight. The
+/// weight of the path also includes start_weight and target_weight.
+pub fn calc_path_multiple_sources_and_targets(
     fast_graph: &FastGraph,
     sources: Vec<(NodeId, Weight)>,
     target: Vec<(NodeId, Weight)>,
 ) -> Option<ShortestPath> {
     let mut calc = PathCalculator::new(fast_graph.get_num_nodes());
-    calc.calc_path_multiple_endpoints(fast_graph, sources, target)
+    calc.calc_path_multiple_sources_and_targets(fast_graph, sources, target)
 }
 
 /// Creates a `PathCalculator` that can be used to run many shortest path calculations in a row.
@@ -230,7 +230,7 @@ mod tests {
                     gen_weighted_nodes(&mut rng, input_graph.get_num_nodes(), NUM_SOURCES);
                 let targets =
                     gen_weighted_nodes(&mut rng, input_graph.get_num_nodes(), NUM_TARGETS);
-                let fast_path = path_calculator.calc_path_multiple_endpoints(
+                let fast_path = path_calculator.calc_path_multiple_sources_and_targets(
                     &fast_graph,
                     sources.clone(),
                     targets.clone(),

--- a/src/path_calculator.rs
+++ b/src/path_calculator.rs
@@ -90,7 +90,10 @@ impl PathCalculator {
 
         for (start_node, start_weight) in &starts {
             for (end_node, end_weight) in &ends {
-                if *start_node == *end_node && *start_weight < WEIGHT_MAX && *end_weight < WEIGHT_MAX {
+                if *start_node == *end_node
+                    && *start_weight < WEIGHT_MAX
+                    && *end_weight < WEIGHT_MAX
+                {
                     if *start_weight + *end_weight < best_weight {
                         best_weight = *start_weight + *end_weight;
                         meeting_node = *end_node;
@@ -199,8 +202,13 @@ impl PathCalculator {
             assert!(best_weight < WEIGHT_MAX);
             let node_ids = self.extract_nodes(graph, meeting_node);
             let chosen_start = node_ids[0];
-            let chosen_end = node_ids[node_ids.len()-1];
-            return Some(ShortestPath::new(chosen_start, chosen_end, best_weight, node_ids));
+            let chosen_end = node_ids[node_ids.len() - 1];
+            return Some(ShortestPath::new(
+                chosen_start,
+                chosen_end,
+                best_weight,
+                node_ids,
+            ));
         }
     }
 

--- a/src/path_calculator.rs
+++ b/src/path_calculator.rs
@@ -196,21 +196,19 @@ impl PathCalculator {
             }
         }
 
-        if meeting_node == INVALID_NODE {
-            return None;
+        return if meeting_node == INVALID_NODE {
+            None
         } else {
             assert!(best_weight < WEIGHT_MAX);
-            let node_ids = self.extract_nodes(graph, meeting_node);
-            assert!(node_ids.len() > 0);
-            let chosen_start = node_ids[0];
-            let chosen_end = node_ids[node_ids.len() - 1];
-            return Some(ShortestPath::new(
-                chosen_start,
-                chosen_end,
+            let nodes = self.extract_nodes(graph, meeting_node);
+            assert!(nodes.len() > 0);
+            Some(ShortestPath::new(
+                nodes[0],
+                nodes[nodes.len() - 1],
                 best_weight,
-                node_ids,
-            ));
-        }
+                nodes,
+            ))
+        };
     }
 
     fn is_stallable_fwd(&self, graph: &FastGraph, curr: HeapItem) -> bool {

--- a/src/path_calculator.rs
+++ b/src/path_calculator.rs
@@ -107,8 +107,13 @@ impl PathCalculator {
                 self.heap_fwd.push(HeapItem::new(weight, id));
             }
         }
-        self.update_node_bwd(end, 0, end, INVALID_EDGE);
-        self.heap_bwd.push(HeapItem::new(0, end));
+        for (id, weight) in ends {
+            if weight < self.get_weight_bwd(id) {
+                // ... same here
+                self.update_node_bwd(id, weight, id, INVALID_EDGE);
+                self.heap_bwd.push(HeapItem::new(0, id));
+            }
+        }
 
         loop {
             if self.heap_fwd.is_empty() && self.heap_bwd.is_empty() {
@@ -193,7 +198,8 @@ impl PathCalculator {
             assert!(best_weight < WEIGHT_MAX);
             let node_ids = self.extract_nodes(graph, meeting_node);
             let chosen_start = node_ids[0];
-            return Some(ShortestPath::new(chosen_start, end, best_weight, node_ids));
+            let chosen_end = node_ids[node_ids.len()-1];
+            return Some(ShortestPath::new(chosen_start, chosen_end, best_weight, node_ids));
         }
     }
 

--- a/src/path_calculator.rs
+++ b/src/path_calculator.rs
@@ -80,9 +80,9 @@ impl PathCalculator {
         self.heap_bwd.clear();
         self.valid_flags_fwd.invalidate_all();
         self.valid_flags_bwd.invalidate_all();
-        for (id, _) in &starts {
+        for (id, weight) in &starts {
             if *id == end {
-                return Some(ShortestPath::singular(*id));
+                return Some(ShortestPath::new(*id, *id, *weight, vec![*id]));
             }
         }
 

--- a/src/path_calculator.rs
+++ b/src/path_calculator.rs
@@ -58,24 +58,28 @@ impl PathCalculator {
         start: NodeId,
         end: NodeId,
     ) -> Option<ShortestPath> {
-        self.calc_path_multiple_endpoints(graph, vec![(start, 0)], end)
+        self.calc_path_multiple_endpoints(graph, vec![(start, 0)], vec![(end, 0)])
     }
 
     pub fn calc_path_multiple_endpoints(
         &mut self,
         graph: &FastGraph,
         starts: Vec<(NodeId, Weight)>,
-        end: NodeId,
+        ends: Vec<(NodeId, Weight)>,
     ) -> Option<ShortestPath> {
         assert_eq!(
             graph.get_num_nodes(),
             self.num_nodes,
             "given graph has invalid node count"
         );
+        assert!(starts.len() > 0, "there has to be at least one start");
+        assert!(ends.len() > 0, "there has to be at least one end");
         for (id, _) in &starts {
             assert!(*id < self.num_nodes, "invalid start node");
         }
-        assert!(end < self.num_nodes, "invalid end node");
+        for (id, _) in &starts {
+            assert!(*id < self.num_nodes, "invalid end node");
+        }
         self.heap_fwd.clear();
         self.heap_bwd.clear();
         self.valid_flags_fwd.invalidate_all();
@@ -84,6 +88,7 @@ impl PathCalculator {
         let mut best_weight = WEIGHT_MAX;
         let mut meeting_node = INVALID_NODE;
 
+        let end = ends[0].0;
         starts
             .iter()
             .filter(|(id, weight)| *id == end && *weight < WEIGHT_MAX)

--- a/src/path_calculator.rs
+++ b/src/path_calculator.rs
@@ -80,10 +80,17 @@ impl PathCalculator {
         self.heap_bwd.clear();
         self.valid_flags_fwd.invalidate_all();
         self.valid_flags_bwd.invalidate_all();
-        for (id, weight) in &starts {
-            if *id == end {
-                return Some(ShortestPath::new(*id, *id, *weight, vec![*id]));
-            }
+        let min_start_end_match = starts
+            .iter()
+            .filter(|(id, _)| *id == end)
+            .min_by_key(|(_, weight)| weight);
+        if min_start_end_match.is_some() {
+            return Some(ShortestPath::new(
+                end,
+                end,
+                min_start_end_match.unwrap().1,
+                vec![end],
+            ));
         }
 
         for (id, weight) in starts {

--- a/src/path_calculator.rs
+++ b/src/path_calculator.rs
@@ -86,7 +86,7 @@ impl PathCalculator {
 
         starts
             .iter()
-            .filter(|(id, _)| *id == end)
+            .filter(|(id, weight)| *id == end && *weight < WEIGHT_MAX)
             .min_by_key(|(_, weight)| weight)
             .map(|(_, weight)| {
                 best_weight = *weight;
@@ -94,8 +94,10 @@ impl PathCalculator {
             });
 
         for (id, weight) in starts {
-            self.update_node_fwd(id, weight, INVALID_NODE, INVALID_EDGE);
-            self.heap_fwd.push(HeapItem::new(weight, id));
+            if weight < WEIGHT_MAX {
+                self.update_node_fwd(id, weight, INVALID_NODE, INVALID_EDGE);
+                self.heap_fwd.push(HeapItem::new(weight, id));
+            }
         }
         self.update_node_bwd(end, 0, INVALID_NODE, INVALID_EDGE);
         self.heap_bwd.push(HeapItem::new(0, end));
@@ -180,6 +182,7 @@ impl PathCalculator {
         if meeting_node == INVALID_NODE {
             return None;
         } else {
+            assert!(best_weight < WEIGHT_MAX);
             let node_ids = self.extract_nodes(graph, end, meeting_node);
             let chosen_start = node_ids[0];
             return Some(ShortestPath::new(chosen_start, end, best_weight, node_ids));

--- a/src/path_calculator.rs
+++ b/src/path_calculator.rs
@@ -94,7 +94,7 @@ impl PathCalculator {
             });
 
         for (id, weight) in starts {
-            if weight < WEIGHT_MAX {
+            if weight < self.get_weight_fwd(id) {
                 self.update_node_fwd(id, weight, INVALID_NODE, INVALID_EDGE);
                 self.heap_fwd.push(HeapItem::new(weight, id));
             }

--- a/src/path_calculator.rs
+++ b/src/path_calculator.rs
@@ -19,11 +19,11 @@
 
 use std::collections::BinaryHeap;
 
-use crate::constants::Weight;
+use crate::constants::{EdgeId, NodeId};
 use crate::constants::INVALID_EDGE;
 use crate::constants::INVALID_NODE;
+use crate::constants::Weight;
 use crate::constants::WEIGHT_MAX;
-use crate::constants::{EdgeId, NodeId};
 use crate::fast_graph::FastGraph;
 use crate::heap_item::HeapItem;
 use crate::shortest_path::ShortestPath;
@@ -80,18 +80,18 @@ impl PathCalculator {
         self.heap_bwd.clear();
         self.valid_flags_fwd.invalidate_all();
         self.valid_flags_bwd.invalidate_all();
-        let min_start_end_match = starts
+
+        let mut best_weight = WEIGHT_MAX;
+        let mut meeting_node = INVALID_NODE;
+
+        starts
             .iter()
             .filter(|(id, _)| *id == end)
-            .min_by_key(|(_, weight)| weight);
-        if min_start_end_match.is_some() {
-            return Some(ShortestPath::new(
-                end,
-                end,
-                min_start_end_match.unwrap().1,
-                vec![end],
-            ));
-        }
+            .min_by_key(|(_, weight)| weight)
+            .map(|(_, weight)| {
+                best_weight = *weight;
+                meeting_node = end;
+            });
 
         for (id, weight) in starts {
             self.update_node_fwd(id, weight, INVALID_NODE, INVALID_EDGE);
@@ -99,9 +99,6 @@ impl PathCalculator {
         }
         self.update_node_bwd(end, 0, INVALID_NODE, INVALID_EDGE);
         self.heap_bwd.push(HeapItem::new(0, end));
-
-        let mut best_weight = WEIGHT_MAX;
-        let mut meeting_node = INVALID_NODE;
 
         loop {
             if self.heap_fwd.is_empty() && self.heap_bwd.is_empty() {

--- a/src/path_calculator.rs
+++ b/src/path_calculator.rs
@@ -88,15 +88,16 @@ impl PathCalculator {
         let mut best_weight = WEIGHT_MAX;
         let mut meeting_node = INVALID_NODE;
 
-        let end = ends[0].0;
-        starts
-            .iter()
-            .filter(|(id, weight)| *id == end && *weight < WEIGHT_MAX)
-            .min_by_key(|(_, weight)| weight)
-            .map(|(_, weight)| {
-                best_weight = *weight;
-                meeting_node = end;
-            });
+        for (start_node, start_weight) in &starts {
+            for (end_node, end_weight) in &ends {
+                if *start_node == *end_node && *start_weight < WEIGHT_MAX && *end_weight < WEIGHT_MAX {
+                    if *start_weight + *end_weight < best_weight {
+                        best_weight = *start_weight + *end_weight;
+                        meeting_node = *end_node;
+                    }
+                }
+            }
+        }
 
         for (id, weight) in starts {
             if weight < self.get_weight_fwd(id) {
@@ -111,7 +112,7 @@ impl PathCalculator {
             if weight < self.get_weight_bwd(id) {
                 // ... same here
                 self.update_node_bwd(id, weight, id, INVALID_EDGE);
-                self.heap_bwd.push(HeapItem::new(0, id));
+                self.heap_bwd.push(HeapItem::new(weight, id));
             }
         }
 

--- a/src/path_calculator.rs
+++ b/src/path_calculator.rs
@@ -19,11 +19,11 @@
 
 use std::collections::BinaryHeap;
 
-use crate::constants::{EdgeId, NodeId};
+use crate::constants::Weight;
 use crate::constants::INVALID_EDGE;
 use crate::constants::INVALID_NODE;
-use crate::constants::Weight;
 use crate::constants::WEIGHT_MAX;
+use crate::constants::{EdgeId, NodeId};
 use crate::fast_graph::FastGraph;
 use crate::heap_item::HeapItem;
 use crate::shortest_path::ShortestPath;


### PR DESCRIPTION
Supercedes #29. Compared to #29 this version includes the starting weights of the source nodes in the final path weight, deals with some edge cases like duplicate source nodes with different start weights and also allows multiple weighted targets.
