### PR TITLE
Add parameters to limit number of settled nodes during preparation, much faster preparation for certain graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,14 +117,14 @@ For this to work `another_input_graph` must have the same number of nodes as `in
 |California&Nevada|1.890.816|4.630.444|
 |USA|23.947.348|57.708.624|
 
-|graph|metric|preparation time|average query time|
-|-|-|-|-|
-|NY city|distance|15 s|108 μs|
-|CAL&NV|distance|70 s|243 μs|
-|USA|distance|21 min|1452 μs|
-|NY city|time|10 s|54 μs|
-|CAL&NV|time|50 s|149 μs|
-|USA|time|11 min|856 μs|
+|graph|metric|preparation time|average query time|out edges|in edges|
+|-|-|-|-|-|-|
+|NY city|distance|13 s|100 μs|747.555|747.559|
+|CAL&NV|distance|57 s|244 μs|4.147.109|4.147.183|
+|USA|distance|17 min|1433 μs|52.617.216|52.617.642|
+|NY city|time|9 s|55 μs|706.053|706.084|
+|CAL&NV|time|42 s|148 μs|3.975.276|3.975.627|
+|USA|time|9.8 min|872 μs|49.277.058|49.283.162|
 
 The shortest path calculation time was averaged over 100k random routing queries. The benchmarks were run using Rust 1.50.0
 

--- a/changelog
+++ b/changelog
@@ -1,5 +1,5 @@
 0.3.0 (not yet released)
-      breaking: add max_settled_nodes parameters to Params, important performance tuning for graphs with large-weight edges
+      breaking: add max_settled_nodes parameters to Params, important performance tuning for graphs with large-weight edges, #37
       add InputGraph::to_file, #35
       faster fast_graph building, 82e9a2ef417af6de1b2cb41bcee41b6302db1b4a
       allow passing &[T] instead of &Vec<T> in a few places, #32

--- a/changelog
+++ b/changelog
@@ -1,7 +1,11 @@
 0.3.0 (not yet released)
+      breaking: add max_settled_nodes parameters to Params, important performance tuning for graphs with large-weight edges
+      add InputGraph::to_file, #35
+      faster fast_graph building, 82e9a2ef417af6de1b2cb41bcee41b6302db1b4a
       allow passing &[T] instead of &Vec<T> in a few places, #32
       add calc_path_multiple_sources_and_targets, #30
-0.2.0 add clone and copy derives, #26
+0.2.0 [April 25th 2021]
+      add clone and copy derives, #26
       faster fast_graph building
       faster queries (stall on demand optimization), #18
       fix serious performance regression for Rust >=1.45, #21
@@ -10,5 +14,7 @@
       WebAssembly compatibility, #11
       deterministic fast_graph building, #10
       license change to dual MIT/Apache 2.0, #4
-0.1.1 adds travis and meta information to Cargo.toml
-0.1.0 initial version
+0.1.1 [June 17th 2019]
+      adds travis and meta information to Cargo.toml
+0.1.0 [June 17th 2019]
+      initial version

--- a/src/fast_graph_builder.rs
+++ b/src/fast_graph_builder.rs
@@ -85,7 +85,7 @@ impl FastGraphBuilder {
                 &mut witness_search,
                 node,
                 0,
-                usize::MAX,
+                20,
             ) as Weight;
             queue.push(node, Reverse(priority));
         }
@@ -126,7 +126,7 @@ impl FastGraphBuilder {
                 &mut preparation_graph,
                 &mut witness_search,
                 node,
-                usize::MAX,
+                100,
             );
             for neighbor in neighbors {
                 levels[neighbor] = max(levels[neighbor], levels[node] + 1);
@@ -136,7 +136,7 @@ impl FastGraphBuilder {
                     &mut witness_search,
                     neighbor,
                     levels[neighbor],
-                    usize::MAX,
+                    20,
                 ) as Weight;
                 queue.change_priority(&neighbor, Reverse(priority));
             }
@@ -188,7 +188,7 @@ impl FastGraphBuilder {
                 &mut preparation_graph,
                 &mut witness_search,
                 node,
-                usize::MAX,
+                100,
             );
             debug!(
                 "contracted node {} / {}, num edges fwd: {}, num edges bwd: {}",

--- a/src/fast_graph_builder.rs
+++ b/src/fast_graph_builder.rs
@@ -85,6 +85,7 @@ impl FastGraphBuilder {
                 &mut witness_search,
                 node,
                 0,
+                usize::MAX,
             ) as Weight;
             queue.push(node, Reverse(priority));
         }
@@ -121,7 +122,12 @@ impl FastGraphBuilder {
             self.fast_graph.first_edge_ids_bwd[rank + 1] = self.fast_graph.get_num_in_edges();
 
             self.fast_graph.ranks[node] = rank;
-            node_contractor::contract_node(&mut preparation_graph, &mut witness_search, node);
+            node_contractor::contract_node(
+                &mut preparation_graph,
+                &mut witness_search,
+                node,
+                usize::MAX,
+            );
             for neighbor in neighbors {
                 levels[neighbor] = max(levels[neighbor], levels[node] + 1);
                 let priority = node_contractor::calc_relevance(
@@ -130,6 +136,7 @@ impl FastGraphBuilder {
                     &mut witness_search,
                     neighbor,
                     levels[neighbor],
+                    usize::MAX,
                 ) as Weight;
                 queue.change_priority(&neighbor, Reverse(priority));
             }
@@ -177,7 +184,12 @@ impl FastGraphBuilder {
             self.fast_graph.first_edge_ids_bwd[rank + 1] = self.fast_graph.get_num_in_edges();
 
             self.fast_graph.ranks[node] = rank;
-            node_contractor::contract_node(&mut preparation_graph, &mut witness_search, node);
+            node_contractor::contract_node(
+                &mut preparation_graph,
+                &mut witness_search,
+                node,
+                usize::MAX,
+            );
             debug!(
                 "contracted node {} / {}, num edges fwd: {}, num edges bwd: {}",
                 rank + 1,

--- a/src/fast_graph_builder.rs
+++ b/src/fast_graph_builder.rs
@@ -269,7 +269,15 @@ impl FastGraphBuilder {
 }
 
 pub struct Params {
+    /// Smaller values typically yield less shortcuts and a faster preparation time. The relation to
+    /// query speeds is less clear. For large values that yield a much higher number of shortcuts
+    /// queries become slow, but otherwise the query speed might only change by a small amount
+    /// when you change this parameter. The optimal value can only be found heuristically for your
+    /// specific graph and can even depend on the other parameters below. We recommend trying
+    /// different values between 0 and 1.
     pub hierarchy_depth_factor: f32,
+    /// This parameter is simply set to 1.0, because only it's relative size compared to
+    /// hierarchy_depth_factor plays a role.
     pub edge_quotient_factor: f32,
     /// The maximum number of settled nodes per witness search performed when priorities are
     /// calculated for all nodes initially. Since this does not take much time you should probably

--- a/src/fast_graph_builder.rs
+++ b/src/fast_graph_builder.rs
@@ -272,20 +272,20 @@ pub struct Params {
     pub hierarchy_depth_factor: f32,
     pub edge_quotient_factor: f32,
     /// The maximum number of settled nodes per witness search performed when priorities are
-    /// calculated for all nodes initially. Since this does not take much time normally you should
-    /// probably keep the default.
+    /// calculated for all nodes initially. Since this does not take much time you should probably
+    /// keep the default.
     pub max_settled_nodes_initial_relevance: usize,
     /// The maximum number of settled nodes per witness search performed when updating priorities
     /// of neighbor nodes after a node was contracted. The preparation time can strongly depend on
-    /// this value and even setting it to 0 might be feasible. Higher values (like ~500+) should
-    /// yield less shortcuts and faster query times at the cost of a longer preparation time. Lower
-    /// values (like ~0-100) should yield faster preparation at the cost of slower query times and
-    /// more shortcuts. To know for sure you should still make your own experiments for your
-    /// specific graph.
+    /// this value and even setting it to a very small value like 0 or 1 might be feasible.
+    /// Higher values (like ~500+) should yield less shortcuts and faster query times at the cost of
+    /// a longer preparation time. Lower values (like ~0-100) should yield a faster preparation at
+    /// the cost of slower query times and more shortcuts. To know for sure you should still run
+    /// your own experiments for your specific graph.
     pub max_settled_nodes_neighbor_relevance: usize,
     /// The maximum number of settled nodes per witness search when contracting a node. Higher values
-    /// like ~500+ mean less shortcuts (fast graph edges), slower preparation and faster queries while
-    /// lower values mean more shortcuts, slower queries and faster preparation.
+    /// like ~500+ mean less shortcuts (fast graph edges), slower preparation and faster queries.
+    /// Lower values mean more shortcuts, slower queries and faster preparation.
     pub max_settled_nodes_contraction: usize,
 }
 
@@ -312,8 +312,8 @@ impl Params {
 
 pub struct ParamsWithOrder {
     /// The maximum number of settled nodes per witness search when contracting a node. Smaller
-    /// values mean slower queries, more shortcuts, but faster preparation time. Note that the
-    /// performance also can strongly depend on the relation between this parameter and
+    /// values mean slower queries, more shortcuts, but a faster preparation. Note that the
+    /// performance can also strongly depend on the relation between this parameter and
     /// Params::max_settled_nodes_contraction that was used to build the FastGraph and obtain the
     /// node ordering initially. In most cases you should use the same value for these two parameters.
     pub max_settled_nodes_contraction_with_order: usize,

--- a/src/fast_graph_builder.rs
+++ b/src/fast_graph_builder.rs
@@ -277,14 +277,14 @@ pub struct Params {
     pub max_settled_nodes_initial_relevance: usize,
     /// The maximum number of settled nodes per witness search performed when updating priorities
     /// of neighbor nodes after a node was contracted. The preparation time can strongly depend on
-    /// this value and even setting it to 0 might be feasible. Higher values (like 500+) should
+    /// this value and even setting it to 0 might be feasible. Higher values (like ~500+) should
     /// yield less shortcuts and faster query times at the cost of a longer preparation time. Lower
-    /// values (like 0-100) should yield faster preparation at the cost of slower query times and
+    /// values (like ~0-100) should yield faster preparation at the cost of slower query times and
     /// more shortcuts. To know for sure you should still make your own experiments for your
     /// specific graph.
     pub max_settled_nodes_neighbor_relevance: usize,
     /// The maximum number of settled nodes per witness search when contracting a node. Higher values
-    /// like 500+ mean less shortcuts (fast graph edges), slower preparation and faster queries while
+    /// like ~500+ mean less shortcuts (fast graph edges), slower preparation and faster queries while
     /// lower values mean more shortcuts, slower queries and faster preparation.
     pub max_settled_nodes_contraction: usize,
 }
@@ -306,13 +306,7 @@ impl Params {
     }
 
     pub fn default() -> Self {
-        Params {
-            hierarchy_depth_factor: 0.1,
-            edge_quotient_factor: 1.0,
-            max_settled_nodes_initial_relevance: 100,
-            max_settled_nodes_neighbor_relevance: 3,
-            max_settled_nodes_contraction: 100,
-        }
+        Params::new(0.1, 500, 100, 500)
     }
 }
 

--- a/src/fast_graph_builder.rs
+++ b/src/fast_graph_builder.rs
@@ -32,15 +32,6 @@ use super::preparation_graph::PreparationGraph;
 use crate::node_contractor;
 use crate::witness_search::WitnessSearch;
 
-// smaller values mean less time is spent on witness searches so building the fast graph takes less time.
-// however, smaller values also mean less witness paths are found so more unnecessary shortcuts
-// will be introduced which means it can take *more* time to build the fast graph.
-// so we need to find a balance betweeen too low and too large values...
-const MAX_SETTLED_NODES_RELEVANCE_MAIN : usize = 20;
-const MAX_SETTLED_NODES_RELEVANCE_NEIGHBORS : usize = 20;
-const MAX_SETTLED_NODES_CONTRACTION : usize = 100;
-const MAX_SETTLED_NODES_CONTRACTION_FIXED : usize = 100;
-
 pub struct FastGraphBuilder {
     fast_graph: FastGraph,
     num_nodes: usize,
@@ -72,13 +63,25 @@ impl FastGraphBuilder {
         input_graph: &InputGraph,
         order: &[NodeId],
     ) -> Result<FastGraph, String> {
+        FastGraphBuilder::build_with_order_with_params(
+            input_graph,
+            order,
+            &ParamsWithOrder::default(),
+        )
+    }
+
+    pub fn build_with_order_with_params(
+        input_graph: &InputGraph,
+        order: &[NodeId],
+        params: &ParamsWithOrder,
+    ) -> Result<FastGraph, String> {
         if input_graph.get_num_nodes() != order.len() {
             return Err(String::from(
                 "The given order must have as many nodes as the input graph",
             ));
         }
         let mut builder = FastGraphBuilder::new(input_graph);
-        builder.run_contraction_with_order(input_graph, order);
+        builder.run_contraction_with_order(input_graph, order, params);
         Ok(builder.fast_graph)
     }
 
@@ -94,7 +97,7 @@ impl FastGraphBuilder {
                 &mut witness_search,
                 node,
                 0,
-                MAX_SETTLED_NODES_RELEVANCE_MAIN,
+                params.max_settled_nodes_initial_relevance,
             ) as Weight;
             queue.push(node, Reverse(priority));
         }
@@ -135,7 +138,7 @@ impl FastGraphBuilder {
                 &mut preparation_graph,
                 &mut witness_search,
                 node,
-                MAX_SETTLED_NODES_CONTRACTION,
+                params.max_settled_nodes_contraction,
             );
             for neighbor in neighbors {
                 levels[neighbor] = max(levels[neighbor], levels[node] + 1);
@@ -145,7 +148,7 @@ impl FastGraphBuilder {
                     &mut witness_search,
                     neighbor,
                     levels[neighbor],
-                    MAX_SETTLED_NODES_RELEVANCE_NEIGHBORS,
+                    params.max_settled_nodes_neighbor_relevance,
                 ) as Weight;
                 queue.change_priority(&neighbor, Reverse(priority));
             }
@@ -161,7 +164,12 @@ impl FastGraphBuilder {
         self.finish_contraction();
     }
 
-    fn run_contraction_with_order(&mut self, input_graph: &InputGraph, order: &[NodeId]) {
+    fn run_contraction_with_order(
+        &mut self,
+        input_graph: &InputGraph,
+        order: &[NodeId],
+        params: &ParamsWithOrder,
+    ) {
         let mut preparation_graph = PreparationGraph::from_input_graph(input_graph);
         let mut witness_search = WitnessSearch::new(self.num_nodes);
         for (rank, node) in order.iter().cloned().enumerate() {
@@ -197,7 +205,7 @@ impl FastGraphBuilder {
                 &mut preparation_graph,
                 &mut witness_search,
                 node,
-                MAX_SETTLED_NODES_CONTRACTION_FIXED,
+                params.max_settled_nodes_contraction_with_order,
             );
             debug!(
                 "contracted node {} / {}, num edges fwd: {}, num edges bwd: {}",
@@ -263,18 +271,69 @@ impl FastGraphBuilder {
 pub struct Params {
     pub hierarchy_depth_factor: f32,
     pub edge_quotient_factor: f32,
+    /// The maximum number of settled nodes per witness search performed when priorities are
+    /// calculated for all nodes initially. Since this does not take much time normally you should
+    /// probably keep the default.
+    pub max_settled_nodes_initial_relevance: usize,
+    /// The maximum number of settled nodes per witness search performed when updating priorities
+    /// of neighbor nodes after a node was contracted. The preparation time can strongly depend on
+    /// this value and even setting it to 0 might be feasible. Higher values (like 500+) should
+    /// yield less shortcuts and faster query times at the cost of a longer preparation time. Lower
+    /// values (like 0-100) should yield faster preparation at the cost of slower query times and
+    /// more shortcuts. To know for sure you should still make your own experiments for your
+    /// specific graph.
+    pub max_settled_nodes_neighbor_relevance: usize,
+    /// The maximum number of settled nodes per witness search when contracting a node. Higher values
+    /// like 500+ mean less shortcuts (fast graph edges), slower preparation and faster queries while
+    /// lower values mean more shortcuts, slower queries and faster preparation.
+    pub max_settled_nodes_contraction: usize,
 }
 
 impl Params {
-    pub fn new(ratio: f32) -> Self {
+    pub fn new(
+        ratio: f32,
+        max_settled_nodes_initial_relevance: usize,
+        max_settled_nodes_neighbor_relevance: usize,
+        max_settled_nodes_contraction: usize,
+    ) -> Self {
         Params {
             hierarchy_depth_factor: ratio,
             edge_quotient_factor: 1.0,
+            max_settled_nodes_initial_relevance,
+            max_settled_nodes_neighbor_relevance,
+            max_settled_nodes_contraction,
         }
     }
 
     pub fn default() -> Self {
-        Params::new(0.1)
+        Params {
+            hierarchy_depth_factor: 0.1,
+            edge_quotient_factor: 1.0,
+            max_settled_nodes_initial_relevance: 100,
+            max_settled_nodes_neighbor_relevance: 3,
+            max_settled_nodes_contraction: 100,
+        }
+    }
+}
+
+pub struct ParamsWithOrder {
+    /// The maximum number of settled nodes per witness search when contracting a node. Smaller
+    /// values mean slower queries, more shortcuts, but faster preparation time. Note that the
+    /// performance also can strongly depend on the relation between this parameter and
+    /// Params::max_settled_nodes_contraction that was used to build the FastGraph and obtain the
+    /// node ordering initially. In most cases you should use the same value for these two parameters.
+    pub max_settled_nodes_contraction_with_order: usize,
+}
+
+impl ParamsWithOrder {
+    pub fn new(max_settled_nodes_contraction_with_order: usize) -> Self {
+        ParamsWithOrder {
+            max_settled_nodes_contraction_with_order,
+        }
+    }
+
+    pub fn default() -> Self {
+        ParamsWithOrder::new(100)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,6 +403,7 @@ mod tests {
         println!("Running performance test for Bremen dist");
         // road network extracted from OSM data from Bremen, Germany using the road distance as weight
         // prep: 190ms, query: 16μs, out: 68494, in: 68426
+        // todo: try to tune parameters
         run_performance_test(
             &InputGraph::from_file("meta/test_maps/bremen_dist.gr"),
             &Params::new(0.1, 500, 2, 50),
@@ -417,6 +418,7 @@ mod tests {
         println!("Running performance test for Bremen time");
         // road network extracted from OSM data from Bremen, Germany using the travel time as weight
         // prep: 256ms, query: 11μs, out: 64825, in: 65027
+        // todo: try to tune parameters
         run_performance_test(
             &InputGraph::from_file("meta/test_maps/bremen_time.gr"),
             &Params::new(0.1, 100, 2, 100),
@@ -430,6 +432,7 @@ mod tests {
     fn run_performance_test_ballard() {
         println!("Running performance test for ballard");
         // prep: 1150ms, query: 53μs, out: 43849, in: 43700
+        // todo: try to tune parameters
         run_performance_test(
             &InputGraph::from_file("meta/test_maps/graph_ballard.gr"),
             &Params::new(0.1, 100, 3, 100),
@@ -443,6 +446,7 @@ mod tests {
     fn run_performance_test_23rd() {
         println!("Running performance test for 23rd");
         // prep: 170ms, query: 23μs, out: 11478, in: 11236
+        // todo: try to tune parameters
         run_performance_test(
             &InputGraph::from_file("meta/test_maps/graph_23rd.gr"),
             &Params::new(0.1, 100, 3, 100),
@@ -456,6 +460,7 @@ mod tests {
     fn run_performance_test_south_seattle_car() {
         println!("Running performance test for South Seattle car");
         // prep: 877ms, query: 26μs, out: 68777, in: 68161
+        // todo: try to tune parameters
         run_performance_test(
             &InputGraph::from_file("meta/test_maps/south_seattle_car.gr"),
             &Params::new(0.1, 100, 10, 100),
@@ -469,6 +474,7 @@ mod tests {
     fn run_performance_test_bremen_dist_fixed_ordering() {
         println!("Running performance test for Bremen dist (fixed node ordering)");
         // prep: 340ms, prep_order: 64ms, query: 16μs, out: 66646, in: 66725
+        // todo: try to tune parameters
         run_performance_test_fixed_ordering(
             &InputGraph::from_file("meta/test_maps/bremen_dist.gr"),
             &Params::default(),
@@ -483,6 +489,7 @@ mod tests {
     fn run_performance_test_south_seattle_fixed_ordering() {
         println!("Running performance test for South Seattle car (fixed node ordering)");
         // prep: 811ms, prep order: 138ms, query: 27μs, out: 68777, in: 68161
+        // todo: try to tune parameters
         run_performance_test_fixed_ordering(
             &InputGraph::from_file("meta/test_maps/south_seattle_car.gr"),
             &Params::new(0.1, 100, 10, 100),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,6 +402,7 @@ mod tests {
     fn run_performance_test_dist() {
         println!("Running performance test for Bremen dist");
         // road network extracted from OSM data from Bremen, Germany using the road distance as weight
+        // prep: 190ms, query: 16μs, out: 68494, in: 68426
         run_performance_test(
             &InputGraph::from_file("meta/test_maps/bremen_dist.gr"),
             &Params::new(0.1, 500, 2, 50),
@@ -415,6 +416,7 @@ mod tests {
     fn run_performance_test_time() {
         println!("Running performance test for Bremen time");
         // road network extracted from OSM data from Bremen, Germany using the travel time as weight
+        // prep: 256ms, query: 11μs, out: 64825, in: 65027
         run_performance_test(
             &InputGraph::from_file("meta/test_maps/bremen_time.gr"),
             &Params::new(0.1, 100, 2, 100),
@@ -427,6 +429,7 @@ mod tests {
     #[test]
     fn run_performance_test_ballard() {
         println!("Running performance test for ballard");
+        // prep: 1150ms, query: 53μs, out: 43849, in: 43700
         run_performance_test(
             &InputGraph::from_file("meta/test_maps/graph_ballard.gr"),
             &Params::new(0.1, 100, 3, 100),
@@ -439,6 +442,7 @@ mod tests {
     #[test]
     fn run_performance_test_23rd() {
         println!("Running performance test for 23rd");
+        // prep: 170ms, query: 23μs, out: 11478, in: 11236
         run_performance_test(
             &InputGraph::from_file("meta/test_maps/graph_23rd.gr"),
             &Params::new(0.1, 100, 3, 100),
@@ -451,6 +455,7 @@ mod tests {
     #[test]
     fn run_performance_test_south_seattle_car() {
         println!("Running performance test for South Seattle car");
+        // prep: 877ms, query: 26μs, out: 68777, in: 68161
         run_performance_test(
             &InputGraph::from_file("meta/test_maps/south_seattle_car.gr"),
             &Params::new(0.1, 100, 10, 100),
@@ -463,6 +468,7 @@ mod tests {
     #[test]
     fn run_performance_test_bremen_dist_fixed_ordering() {
         println!("Running performance test for Bremen dist (fixed node ordering)");
+        // prep: 340ms, prep_order: 64ms, query: 16μs, out: 66646, in: 66725
         run_performance_test_fixed_ordering(
             &InputGraph::from_file("meta/test_maps/bremen_dist.gr"),
             &Params::default(),
@@ -476,6 +482,7 @@ mod tests {
     #[test]
     fn run_performance_test_south_seattle_fixed_ordering() {
         println!("Running performance test for South Seattle car (fixed node ordering)");
+        // prep: 811ms, prep order: 138ms, query: 27μs, out: 68777, in: 68161
         run_performance_test_fixed_ordering(
             &InputGraph::from_file("meta/test_maps/south_seattle_car.gr"),
             &Params::new(0.1, 100, 10, 100),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,7 +418,7 @@ mod tests {
         println!("Running performance test for ballard");
         run_performance_test(
             &InputGraph::from_file("meta/test_maps/graph_ballard.gr"),
-            &Params::new(0.01),
+            &Params::default(),
             28409159409,
             14992,
         );

--- a/src/witness_search.rs
+++ b/src/witness_search.rs
@@ -52,9 +52,9 @@ impl WitnessSearch {
     /// Initializes the witness search for a given start and avoid node. Calling this method
     /// resets/clears previously calculated data.
     pub fn init(&mut self, start: NodeId, avoid_node: NodeId) {
-        assert!(start != INVALID_NODE, "the start node must be valid");
-        assert!(
-            start != avoid_node,
+        assert_ne!(start, INVALID_NODE, "the start node must be valid");
+        assert_ne!(
+            start, avoid_node,
             "path calculation must not start with avoided node"
         );
         self.start_node = start;
@@ -94,8 +94,8 @@ impl WitnessSearch {
             self.num_nodes,
             "given graph has invalid node count"
         );
-        assert!(
-            self.start_node != INVALID_NODE,
+        assert_ne!(
+            self.start_node, INVALID_NODE,
             "the start node must be valid, call init() before find_max_weight()"
         );
         assert!(

--- a/src/witness_search.rs
+++ b/src/witness_search.rs
@@ -32,6 +32,7 @@ pub struct WitnessSearch {
     heap: BinaryHeap<HeapItem>,
     start_node: NodeId,
     avoid_node: NodeId,
+    settled_nodes: usize,
 }
 
 impl WitnessSearch {
@@ -44,6 +45,7 @@ impl WitnessSearch {
             heap,
             start_node: INVALID_NODE,
             avoid_node: INVALID_NODE,
+            settled_nodes: 0,
         }
     }
 
@@ -62,6 +64,7 @@ impl WitnessSearch {
         self.valid_flags.invalidate_all();
         self.update_node(start, 0);
         self.heap.push(HeapItem::new(0, start));
+        self.settled_nodes = 0;
     }
 
     /// Returns an upper bound for the shortest path weight between the start node and a given target
@@ -75,6 +78,8 @@ impl WitnessSearch {
     ///   3) the tentative weight of the target is found to be equal or smaller than weight_limit.
     ///      this way the search can be stopped without finding the actual shortest path as soon as
     ///      any path with weight <= weight_limit has been found.
+    ///   4) settled_nodes_limit nodes have been settled. the returned weight will be the best known
+    ///      upper bound for the real shortest path weight at this point.
     /// The shortest path tree established during the search will be re-used until the init
     /// function is called again.
     pub fn find_max_weight(
@@ -82,6 +87,7 @@ impl WitnessSearch {
         graph: &PreparationGraph,
         target: NodeId,
         weight_limit: Weight,
+        settled_nodes_limit: usize,
     ) -> Weight {
         assert_eq!(
             graph.get_num_nodes(),
@@ -105,6 +111,9 @@ impl WitnessSearch {
             return self.data[target].weight;
         }
         while !self.heap.is_empty() {
+            if self.settled_nodes >= settled_nodes_limit {
+                break;
+            }
             let curr = *self.heap.peek().unwrap();
             if curr.weight > weight_limit {
                 break;
@@ -132,6 +141,7 @@ impl WitnessSearch {
                 }
             }
             self.data[curr.node_id].settled = true;
+            self.settled_nodes += 1;
             if found_target || curr.node_id == target {
                 break;
             }
@@ -191,10 +201,16 @@ mod tests {
         g.add_edge(5, 2, 1);
         let mut ws = WitnessSearch::new(g.get_num_nodes());
         ws.init(0, INVALID_NODE);
-        assert_eq!(2, ws.find_max_weight(&g, 2, 2));
-        assert_eq!(2, ws.find_max_weight(&g, 2, 2));
+        assert_eq!(2, ws.find_max_weight(&g, 2, 2, 100));
+        assert_eq!(2, ws.find_max_weight(&g, 2, 2, 100));
+        assert_eq!(2, ws.settled_nodes);
         ws.init(0, 1);
-        assert_eq!(13, ws.find_max_weight(&g, 2, 13));
+        assert_eq!(13, ws.find_max_weight(&g, 2, 13, 100));
+        assert_eq!(4, ws.settled_nodes);
+        // calling init again also resets settled nodes
+        ws.init(4, 3);
+        assert_eq!(2, ws.find_max_weight(&g, 2, 5, 100));
+        assert_eq!(2, ws.settled_nodes);
     }
 
     #[test]
@@ -206,23 +222,27 @@ mod tests {
         }
         let mut ws = WitnessSearch::new(g.get_num_nodes());
         ws.init(0, INVALID_NODE);
-        assert_eq!(3, ws.find_max_weight(&g, 3, 3));
+        assert_eq!(3, ws.find_max_weight(&g, 3, 3, 100));
+        assert_eq!(3, ws.settled_nodes);
         // reset and reduce weight limit to 2. node 3 will not be settled, but we still get 3 as
         // upper bound for the weight of node 3
         ws.init(0, INVALID_NODE);
-        assert_eq!(3, ws.find_max_weight(&g, 3, 2));
+        assert_eq!(3, ws.find_max_weight(&g, 3, 2, 100));
+        assert_eq!(3, ws.settled_nodes);
         // .. but not for node 4
-        assert_eq!(WEIGHT_MAX, ws.find_max_weight(&g, 4, 2));
+        assert_eq!(WEIGHT_MAX, ws.find_max_weight(&g, 4, 2, 100));
         // if the weight has already be calculated no further search is required
-        assert_eq!(2, ws.find_max_weight(&g, 2, 2));
-        assert_eq!(2, ws.find_max_weight(&g, 2, 2));
-        assert_eq!(2, ws.find_max_weight(&g, 2, 2));
+        assert_eq!(2, ws.find_max_weight(&g, 2, 2, 100));
+        assert_eq!(2, ws.find_max_weight(&g, 2, 2, 100));
+        assert_eq!(2, ws.find_max_weight(&g, 2, 2, 100));
         // ... even when the weight limit is smaller than previously
-        assert_eq!(2, ws.find_max_weight(&g, 2, 1));
+        assert_eq!(2, ws.find_max_weight(&g, 2, 1, 100));
+        assert_eq!(3, ws.settled_nodes);
         // we can extend the current search space
-        assert_eq!(4, ws.find_max_weight(&g, 4, 3));
-        assert_eq!(4, ws.find_max_weight(&g, 4, 4));
-        assert_eq!(4, ws.find_max_weight(&g, 4, 5));
+        assert_eq!(4, ws.find_max_weight(&g, 4, 3, 100));
+        assert_eq!(4, ws.find_max_weight(&g, 4, 4, 100));
+        assert_eq!(4, ws.find_max_weight(&g, 4, 5, 100));
+        assert_eq!(4, ws.settled_nodes);
     }
 
     #[test]
@@ -238,15 +258,81 @@ mod tests {
         ws.init(0, INVALID_NODE);
         // the shortest path weight is 3, but since we set the limit to 10 the alternative path
         // 0->3 with weight 4 that we find earlier is 'good enough' and find_max_weight returns
-        assert_eq!(4, ws.find_max_weight(&g, 3, 10));
+        // early
+        assert_eq!(4, ws.find_max_weight(&g, 3, 10, 100));
+        assert_eq!(1, ws.settled_nodes);
         // calling the same again still does not trigger an expansion of the search tree
-        assert_eq!(4, ws.find_max_weight(&g, 3, 10));
+        assert_eq!(4, ws.find_max_weight(&g, 3, 10, 100));
+        assert_eq!(1, ws.settled_nodes);
         // this is still true when we reduce the weight limit to the weight of the sub-optimal path
-        assert_eq!(4, ws.find_max_weight(&g, 3, 4));
-        assert_eq!(4, ws.find_max_weight(&g, 3, 4));
+        assert_eq!(4, ws.find_max_weight(&g, 3, 4, 100));
+        assert_eq!(4, ws.find_max_weight(&g, 3, 4, 100));
+        assert_eq!(1, ws.settled_nodes);
         // when we further reduce the weight limit the search needs to be more accurate
-        assert_eq!(3, ws.find_max_weight(&g, 3, 3));
+        assert_eq!(3, ws.find_max_weight(&g, 3, 3, 100));
+        // ... even though settling node 3 is still not necessary
+        assert_eq!(3, ws.settled_nodes);
         // ... and repeating the search yields the same result
-        assert_eq!(3, ws.find_max_weight(&g, 3, 3));
+        assert_eq!(3, ws.find_max_weight(&g, 3, 3, 100));
+        assert_eq!(3, ws.settled_nodes);
+
+        // we can also limit the number of settled nodes
+        ws.init(0, INVALID_NODE);
+        // ... here the weight limit is so large that the alternative path is returned anyway
+        assert_eq!(4, ws.find_max_weight(&g, 3, 100, 2));
+        assert_eq!(1, ws.settled_nodes);
+        // ... here the weight limit does not allow the suboptimal weight to be returned, but once
+        // the settled_nodes_limit is exceeded it is returned anyway
+        assert_eq!(4, ws.find_max_weight(&g, 3, 3, 2));
+        assert_eq!(2, ws.settled_nodes);
+    }
+
+    #[test]
+    fn large_edge_weight() {
+        // 100 <- 99 <- ... <- 3 -> 2 -> 1
+        //                      \-> 0 ->/
+        let mut g = PreparationGraph::new(101);
+        g.add_edge(3, 2, 100);
+        g.add_edge(2, 1, 100);
+        g.add_edge(3, 0, 50);
+        g.add_edge(0, 1, 50);
+        for i in 3..100 {
+            g.add_edge(i, i + 1, 1);
+        }
+        let mut ws = WitnessSearch::new(g.get_num_nodes());
+        // going from 3 to 1 while skipping 2 requires travelling along the large weight edge 3->0
+        // this means many low weight edges will be visited first which slows down the search
+        ws.init(3, 2);
+        assert_eq!(100, ws.find_max_weight(&g, 1, 200, usize::MAX));
+        assert_eq!(51, ws.settled_nodes);
+        // we can improve this by limiting the number of settled nodes. however, in this case
+        // we won't find the witness and risk inserting an unnecessary shortcut. this might or might
+        // not be ok depending on the situation.
+        ws.init(3, 2);
+        assert_eq!(WEIGHT_MAX, ws.find_max_weight(&g, 1, 200, 5));
+        assert_eq!(5, ws.settled_nodes);
+    }
+
+    #[test]
+    fn large_edge_weight_target_touched() {
+        // 100 <- 99 <- ... <- 3 -> 2 -> 1
+        //                      \-> 0 ->/
+        let mut g = PreparationGraph::new(101);
+        g.add_edge(3, 2, 100);
+        g.add_edge(2, 1, 100);
+        g.add_edge(3, 0, 1);
+        g.add_edge(0, 1, 99);
+        for i in 3..100 {
+            g.add_edge(i, i + 1, 1);
+        }
+        let mut ws = WitnessSearch::new(g.get_num_nodes());
+        // going from 3 to 1 while skipping 2 requires travelling the large weight edge 0->1 so
+        // before 1 is settled many other nodes will be settled. however, find_max_weight already
+        // returns even before node 1 is settled because the tentative weight is small enough
+        ws.init(3, 2);
+        assert_eq!(100, ws.find_max_weight(&g, 1, 200, usize::MAX));
+        // .. just two settled nodes. this is quite important for preparation speed when there are
+        // large weight edges
+        assert_eq!(2, ws.settled_nodes);
     }
 }


### PR DESCRIPTION
Fixes #34.

Long story short: When there are large-weight edges the preparation time can become much slower because witness searches explore too many nodes. Preventing this and still not adding too many shortcuts is non-trivial, so this PR introduces some parameters that can be used to tune performance depending for different types of graphs. It also provides some default values that should work reasonably well in most cases.

todo: 

* [x] update benchmark values in README.md
* [x] add benchmark values to mini-performance tests in `lib.rs` and maybe further tune parameters